### PR TITLE
Using the ES6 syntax

### DIFF
--- a/blackmothersfilm/src/App.js
+++ b/blackmothersfilm/src/App.js
@@ -5,14 +5,18 @@ import Header from "./components/Header";
 import Navbar from "./components/Navbar";
 import Main from "./components/Main";
 import Footer from "./components/Footer";
-
-export default function App() {
-  return (
-    <div className="container">
-      <Header />
-      <Navbar />
-      <Main />
-      <Footer />
-    </div>
-  );
+export default class App extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+  render() {
+    return (
+      <div className="container">
+        <Header />
+        <Navbar />
+        <Main />
+        <Footer />
+      </div>
+    );
+  }
 }


### PR DESCRIPTION
I didn't know the export default could be written before the "class App extends React.Component" portion of the code.